### PR TITLE
feat(helm): reusable Helm chart for db-migrator

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,40 @@
+name: Release Helm Chart
+
+# Publishes the chart to the gh-pages branch as a Helm repository and creates a
+# GitHub Release tagged "db-migrator-<version>". A new release is cut only when
+# charts/db-migrator/Chart.yaml `version` is bumped (chart-releaser skips versions
+# that are already published).
+#
+# One-time setup: create an empty `gh-pages` branch and enable GitHub Pages for it
+# (Settings -> Pages -> Branch: gh-pages). The published repo URL will be:
+#   https://raoptimus.github.io/db-migrator.go
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'charts/**'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .*
 !.github
 !.docker
+!.helmignore
 *.md
 !README.md
 build.sh

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ DOCKER_ID_USER = raoptimus
 DOCKER_PASS ?= ""
 DOCKER_IMAGE = "${PKG_NAME}"
 export GO_IMAGE_VERSION="1.26"
+HELM_CHART_DIR = charts/db-migrator
+HELM_DIST_DIR ?= ${BUILD_DIR}/charts
 
 help: ## Show help message
 	@cat $(MAKEFILE_LIST) | grep -e "^[a-zA-Z_\-]*: *.*## *" | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -137,6 +139,16 @@ gen-mocks-dry-run: install-mockery ## Run mockery --dry-run=true
 	mockery --srcpkg=$${d} --output=$${d}/mock$$(basename -- "$${d/./''}") --all --dry-run=true; \
 	done; \
 	'
+
+helm-lint: ## Lint the Helm chart
+	@helm lint ${HELM_CHART_DIR} -f ${HELM_CHART_DIR}/ci/example-values.yaml
+
+helm-template: ## Render the Helm chart to stdout
+	@helm template db-migrator ${HELM_CHART_DIR} -f ${HELM_CHART_DIR}/ci/example-values.yaml
+
+helm-package: helm-lint ## Package the Helm chart into ${HELM_DIST_DIR}
+	@[ -d ${HELM_DIST_DIR} ] || mkdir -p ${HELM_DIST_DIR}
+	@helm package ${HELM_CHART_DIR} --destination ${HELM_DIST_DIR}
 
 start:
 	@docker-compose -f "docker-compose.yml" -f "docker-compose.dev.yml" up -d

--- a/README.md
+++ b/README.md
@@ -280,6 +280,49 @@ Migrated up successfully
 
 ---
 
+## Running in Kubernetes (Helm)
+
+A reusable Helm chart lives in [`charts/db-migrator`](charts/db-migrator). It runs the tool
+as a Kubernetes `Job`:
+
+- **`release`** — applies pending migrations. Rendered as a Helm hook
+  (`pre-install,pre-upgrade`), so the schema is ready before application pods roll out.
+- **`rollback`** — reverts the latest release batch. Opt-in plain `Job` (disabled by default),
+  triggered explicitly, so it works the same under plain Helm and [werf](https://werf.io).
+
+The DSN is referenced from an existing `Secret` (never stored in values), and `INTERACTIVE`
+is always forced to `false` because a Job has no TTY.
+
+```bash
+kubectl create secret generic db-migrator-dsn \
+  --from-literal=dsn='postgres://user:pass@postgres:5432/app?sslmode=disable'
+
+helm install my-migrations ./charts/db-migrator \
+  --set image.repository=myregistry/myapp-migrations \
+  --set image.tag=1.4.2 \
+  --set migrator.dsn.existingSecret=db-migrator-dsn
+```
+
+The base image ships no migrations — build your own image with them baked in:
+
+```dockerfile
+FROM raoptimus/db-migrator:1.7.0
+COPY ./migrations /migrations
+```
+
+To roll back the latest batch, enable the rollback Job explicitly:
+
+```bash
+helm upgrade --install my-migrations ./charts/db-migrator \
+  --reuse-values --set rollback.enabled=true
+```
+
+The chart can also be consumed as a subchart dependency. See
+[`charts/db-migrator/README.md`](charts/db-migrator/README.md) for the full values reference
+and usage examples. Local helpers: `make helm-lint`, `make helm-template`, `make helm-package`.
+
+---
+
 ## Placeholders in Migrations
 
 You can use placeholders in your migration SQL files that will be replaced at runtime:

--- a/charts/db-migrator/.helmignore
+++ b/charts/db-migrator/.helmignore
@@ -1,0 +1,10 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+*.tmproj
+*.bak
+*.orig
+*.swp
+.idea/
+.vscode/

--- a/charts/db-migrator/Chart.yaml
+++ b/charts/db-migrator/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: db-migrator
+description: >-
+  Reusable Helm chart that runs raoptimus/db-migrator as a Kubernetes Job.
+  Applies pending migrations via the `release` command (Helm hook) and reverts
+  the latest release batch via the `rollback` command (opt-in Job). Works both
+  standalone and as a subchart dependency, under plain Helm and werf.
+type: application
+# Chart version (SemVer). Bump on any chart change.
+version: 0.1.0
+# Version of the db-migrator tool this chart targets; used as the default image tag.
+appVersion: "1.7.0"
+home: https://github.com/raoptimus/db-migrator.go
+sources:
+  - https://github.com/raoptimus/db-migrator.go
+  - https://hub.docker.com/r/raoptimus/db-migrator
+maintainers:
+  - name: raoptimus
+    url: https://github.com/raoptimus
+keywords:
+  - migration
+  - database
+  - clickhouse
+  - postgres
+  - mysql
+  - tarantool
+  - iceberg

--- a/charts/db-migrator/README.md
+++ b/charts/db-migrator/README.md
@@ -1,0 +1,147 @@
+# db-migrator Helm chart
+
+Reusable Helm chart that runs [`raoptimus/db-migrator`](https://hub.docker.com/r/raoptimus/db-migrator)
+as a Kubernetes `Job`.
+
+- **`release`** — applies all pending migrations atomically. Rendered as a Helm hook
+  (`pre-install,pre-upgrade` by default), so the schema is ready **before** the application
+  pods roll out.
+- **`rollback`** — reverts the latest release batch. Rendered as an opt-in plain `Job`
+  (disabled by default), triggered explicitly. It is not a lifecycle hook, so it works the
+  same under both plain Helm and [werf](https://werf.io) `converge`.
+
+The chart works standalone (`helm install`) and as a subchart dependency of an application
+chart. `INTERACTIVE` is always forced to `false` because a Job has no TTY.
+
+## Prerequisites
+
+- Kubernetes cluster and Helm 3.
+- A container image that contains your migration files at `migrator.path`
+  (default `/migrations`). The base image ships **no** migrations — see
+  [Providing migrations](#providing-migrations).
+- An existing `Secret` holding the database DSN.
+
+## Installation
+
+```bash
+kubectl create secret generic db-migrator-dsn \
+  --from-literal=dsn='postgres://user:pass@postgres:5432/app?sslmode=disable'
+
+helm install my-migrations ./charts/db-migrator \
+  --set image.repository=myregistry/myapp-migrations \
+  --set image.tag=1.4.2 \
+  --set migrator.dsn.existingSecret=db-migrator-dsn
+```
+
+## Use as a subchart dependency
+
+```yaml
+# Chart.yaml of your application chart
+dependencies:
+  - name: db-migrator
+    version: "0.1.0"
+    repository: "oci://<registry>/charts"   # or https://<repo>, or file://../charts/db-migrator
+```
+
+```yaml
+# values.yaml of your application chart (values go under the "db-migrator" key)
+db-migrator:
+  image:
+    repository: myregistry/myapp-migrations
+    tag: "1.4.2"
+  migrator:
+    dsn:
+      existingSecret: myapp-db
+      secretKey: dsn
+    path: /migrations
+```
+
+Then `helm dependency update && helm upgrade --install ...` — the `release` hook runs on
+every install/upgrade before the app pods start.
+
+## Rolling back
+
+`rollback` is opt-in. Enable it explicitly when you actually want to revert the latest batch:
+
+```bash
+# werf or plain Helm
+helm upgrade --install my-migrations ./charts/db-migrator \
+  --reuse-values --set rollback.enabled=true
+```
+
+Under **plain Helm** you may instead wire rollback to `helm rollback` by turning the Job into
+a hook (this does not fire under werf converge):
+
+```bash
+helm install ... --set 'rollback.hookTypes={pre-rollback}'
+helm rollback my-migrations
+```
+
+## Providing migrations
+
+The base image contains no migrations. Recommended: build your own image.
+
+```dockerfile
+FROM raoptimus/db-migrator:1.7.0
+COPY ./migrations /migrations
+```
+
+Alternatively, mount migrations without rebuilding the image via passthrough values, e.g. a
+ConfigMap:
+
+```yaml
+extraVolumes:
+  - name: migrations
+    configMap:
+      name: myapp-migrations
+extraVolumeMounts:
+  - name: migrations
+    mountPath: /migrations
+migrator:
+  path: /migrations
+```
+
+`initContainers` is also passed through (e.g. for a git-sync sidecar populating an
+`emptyDir`).
+
+## Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.repository` | `raoptimus/db-migrator` | Image containing the migrations |
+| `image.tag` | `""` (→ `.Chart.AppVersion`) | Image tag |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy |
+| `imagePullSecrets` | `[]` | Image pull secrets |
+| `migrator.dsn.existingSecret` | `""` (**required**) | Secret holding the DSN |
+| `migrator.dsn.secretKey` | `dsn` | Key inside the Secret |
+| `migrator.path` | `/migrations` | `MIGRATION_PATH` |
+| `migrator.table` | `migration` | `MIGRATION_TABLE` |
+| `migrator.clusterName` | `""` | `MIGRATION_CLUSTER_NAME` (ClickHouse) |
+| `migrator.replicated` | `false` | `MIGRATION_REPLICATED` (ClickHouse) |
+| `migrator.maxConnAttempts` | `1` | `MAX_CONN_ATTEMPTS` |
+| `migrator.compact` | `false` | `COMPACT` |
+| `migrator.dryRun` | `false` | `DRY_RUN` |
+| `migrator.placeholderCustom` | `""` | `PLACEHOLDER_CUSTOM` |
+| `migrator.extraEnv` | `[]` | Extra env entries |
+| `migrator.extraEnvFrom` | `[]` | Extra `envFrom` sources |
+| `release.enabled` | `true` | Render the release hook Job |
+| `release.command` | `release` | Command (`release` or `up`) |
+| `release.hookTypes` | `[pre-install, pre-upgrade]` | Helm hook phases |
+| `release.weight` | `"5"` | Hook weight |
+| `release.deletePolicy` | `before-hook-creation` | Hook delete policy |
+| `release.annotations` | `{werf.io/fail-mode: FailWholeDeployProcessImmediately}` | Extra Job annotations |
+| `rollback.enabled` | `false` | Render the rollback Job (opt-in) |
+| `rollback.command` | `rollback` | Command |
+| `rollback.hookTypes` | `[]` | Empty = plain Job; `[pre-rollback]` = hook |
+| `rollback.weight` | `"5"` | Hook weight (when hookTypes set) |
+| `rollback.deletePolicy` | `before-hook-creation` | Hook delete policy |
+| `rollback.annotations` | `{}` | Extra Job annotations |
+| `backoffLimit` | `0` | Job `backoffLimit` |
+| `activeDeadlineSeconds` | `3600` | Job `activeDeadlineSeconds` |
+| `ttlSecondsAfterFinished` | `30` | Job TTL after completion |
+| `resources` | `{}` | Container resources |
+| `serviceAccount.create` | `false` | Create a ServiceAccount |
+| `serviceAccount.name` | `""` | ServiceAccount name |
+| `nodeSelector` / `tolerations` / `affinity` | `{}` / `[]` / `{}` | Scheduling |
+| `podSecurityContext` / `securityContext` | `{}` | Security contexts |
+| `initContainers` / `extraVolumes` / `extraVolumeMounts` | `[]` | Migration delivery passthrough |

--- a/charts/db-migrator/ci/example-values.yaml
+++ b/charts/db-migrator/ci/example-values.yaml
@@ -1,0 +1,15 @@
+# Values used to render the chart in CI (`helm lint` / `helm template`).
+# rollback is enabled here so both Jobs are exercised during linting.
+image:
+  repository: raoptimus/db-migrator
+  tag: "1.7.0"
+
+migrator:
+  dsn:
+    existingSecret: db-migrator-dsn
+    secretKey: dsn
+  path: /migrations
+  table: migration
+
+rollback:
+  enabled: true

--- a/charts/db-migrator/templates/NOTES.txt
+++ b/charts/db-migrator/templates/NOTES.txt
@@ -1,0 +1,22 @@
+db-migrator has been deployed as release "{{ .Release.Name }}".
+
+{{ if .Values.release.enabled -}}
+A migration Job runs the "{{ .Values.release.command }}" command as a Helm hook
+({{ join "," .Values.release.hookTypes }}), so it executes before the application pods roll out.
+
+Watch its progress:
+  kubectl -n {{ .Release.Namespace }} get job {{ include "db-migrator.fullname" . }}-release
+  kubectl -n {{ .Release.Namespace }} logs job/{{ include "db-migrator.fullname" . }}-release
+{{- else -}}
+The release Job is disabled (release.enabled=false); no migrations were applied.
+{{- end }}
+
+Rolling back the latest release batch (opt-in):
+  # werf or plain Helm: enable the rollback Job explicitly
+  helm upgrade --install {{ .Release.Name }} <chart> --reuse-values --set rollback.enabled=true
+  # plain Helm alternative: wire it to `helm rollback`
+  #   --set rollback.hookTypes={pre-rollback}
+
+Reminder: the image "{{ include "db-migrator.image" . }}" must contain the migration files
+at MIGRATION_PATH ({{ .Values.migrator.path }}). Build your own image FROM raoptimus/db-migrator
+with the migrations COPY'd in, or mount them via extraVolumes/extraVolumeMounts.

--- a/charts/db-migrator/templates/_helpers.tpl
+++ b/charts/db-migrator/templates/_helpers.tpl
@@ -1,0 +1,171 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "db-migrator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+Truncated at 63 chars because some Kubernetes name fields are limited to this.
+*/}}
+{{- define "db-migrator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name and version as used by the chart label.
+*/}}
+{{- define "db-migrator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "db-migrator.labels" -}}
+helm.sh/chart: {{ include "db-migrator.chart" . }}
+{{ include "db-migrator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "db-migrator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "db-migrator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Name of the service account to use.
+*/}}
+{{- define "db-migrator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "db-migrator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Fully qualified image reference. Tag falls back to the chart appVersion.
+*/}}
+{{- define "db-migrator.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}
+
+{{/*
+Container env block shared by the release and rollback Jobs.
+DSN is required and pulled from an existing Secret via secretKeyRef.
+INTERACTIVE is hard-coded to "false": a Job has no TTY.
+*/}}
+{{- define "db-migrator.env" -}}
+{{- $secret := required "migrator.dsn.existingSecret is required: provide the name of a Secret holding the DSN" .Values.migrator.dsn.existingSecret -}}
+- name: DSN
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secret }}
+      key: {{ .Values.migrator.dsn.secretKey }}
+- name: MIGRATION_PATH
+  value: {{ .Values.migrator.path | quote }}
+- name: MIGRATION_TABLE
+  value: {{ .Values.migrator.table | quote }}
+{{- if .Values.migrator.clusterName }}
+- name: MIGRATION_CLUSTER_NAME
+  value: {{ .Values.migrator.clusterName | quote }}
+{{- end }}
+- name: MIGRATION_REPLICATED
+  value: {{ .Values.migrator.replicated | quote }}
+- name: MAX_CONN_ATTEMPTS
+  value: {{ .Values.migrator.maxConnAttempts | quote }}
+- name: COMPACT
+  value: {{ .Values.migrator.compact | quote }}
+- name: INTERACTIVE
+  value: "false"
+- name: DRY_RUN
+  value: {{ .Values.migrator.dryRun | quote }}
+{{- if .Values.migrator.placeholderCustom }}
+- name: PLACEHOLDER_CUSTOM
+  value: {{ .Values.migrator.placeholderCustom | quote }}
+{{- end }}
+{{- with .Values.migrator.extraEnv }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Shared pod spec for the migration Jobs.
+Usage: include "db-migrator.podSpec" (dict "root" . "command" "release")
+*/}}
+{{- define "db-migrator.podSpec" -}}
+{{- $root := .root -}}
+{{- $command := .command -}}
+restartPolicy: {{ $root.Values.restartPolicy }}
+{{- with $root.Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+serviceAccountName: {{ include "db-migrator.serviceAccountName" $root }}
+{{- with $root.Values.podSecurityContext }}
+securityContext:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $root.Values.initContainers }}
+initContainers:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+containers:
+  - name: db-migrator
+    image: {{ include "db-migrator.image" $root }}
+    imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+    args:
+      - {{ $command | quote }}
+    {{- with $root.Values.securityContext }}
+    securityContext:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    env:
+      {{- include "db-migrator.env" $root | nindent 6 }}
+    {{- with $root.Values.migrator.extraEnvFrom }}
+    envFrom:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $root.Values.extraVolumeMounts }}
+    volumeMounts:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $root.Values.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- with $root.Values.extraVolumes }}
+volumes:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $root.Values.nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $root.Values.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $root.Values.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/db-migrator/templates/job-release.yaml
+++ b/charts/db-migrator/templates/job-release.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.release.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "db-migrator.fullname" . }}-release
+  labels:
+    {{- include "db-migrator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: release
+  annotations:
+    "helm.sh/hook": {{ join "," .Values.release.hookTypes | quote }}
+    "helm.sh/hook-weight": {{ .Values.release.weight | quote }}
+    "helm.sh/hook-delete-policy": {{ .Values.release.deletePolicy | quote }}
+    {{- with .Values.release.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
+  ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "db-migrator.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: release
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "db-migrator.podSpec" (dict "root" . "command" .Values.release.command) | nindent 6 }}
+{{- end }}

--- a/charts/db-migrator/templates/job-rollback.yaml
+++ b/charts/db-migrator/templates/job-rollback.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.rollback.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # Revision suffix keeps the name unique so a rollback can be re-run on a later deploy
+  # (Jobs are immutable once created).
+  name: {{ include "db-migrator.fullname" . }}-rollback-r{{ .Release.Revision }}
+  labels:
+    {{- include "db-migrator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollback
+  {{- if or .Values.rollback.hookTypes .Values.rollback.annotations }}
+  annotations:
+    {{- if .Values.rollback.hookTypes }}
+    "helm.sh/hook": {{ join "," .Values.rollback.hookTypes | quote }}
+    "helm.sh/hook-weight": {{ .Values.rollback.weight | quote }}
+    "helm.sh/hook-delete-policy": {{ .Values.rollback.deletePolicy | quote }}
+    {{- end }}
+    {{- with .Values.rollback.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  backoffLimit: {{ .Values.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
+  ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "db-migrator.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: rollback
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "db-migrator.podSpec" (dict "root" . "command" .Values.rollback.command) | nindent 6 }}
+{{- end }}

--- a/charts/db-migrator/templates/serviceaccount.yaml
+++ b/charts/db-migrator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "db-migrator.serviceAccountName" . }}
+  labels:
+    {{- include "db-migrator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/db-migrator/values.yaml
+++ b/charts/db-migrator/values.yaml
@@ -1,0 +1,103 @@
+# Default values for db-migrator.
+
+# Container image. Override `repository`/`tag` with your own image that contains
+# the migration files (built FROM raoptimus/db-migrator with the migrations COPY'd in).
+image:
+  repository: raoptimus/db-migrator
+  # tag "" falls back to .Chart.AppVersion.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# Secrets used to pull the image, e.g. [{name: my-registry}].
+imagePullSecrets: []
+
+# Overrides for generated resource names.
+nameOverride: ""
+fullnameOverride: ""
+
+# db-migrator configuration. Every field maps to an environment variable read by
+# the CLI (see cmd/db-migrator/main.go).
+migrator:
+  dsn:
+    # REQUIRED: name of an existing Secret holding the database DSN.
+    # The chart never stores the DSN itself; it references the Secret via secretKeyRef.
+    existingSecret: ""
+    # Key inside that Secret whose value is the DSN.
+    secretKey: dsn
+  # MIGRATION_PATH: directory with migration files inside the image/volume.
+  path: /migrations
+  # MIGRATION_TABLE: history table (or Iceberg namespace) name.
+  table: migration
+  # MIGRATION_CLUSTER_NAME: ClickHouse cluster name (empty disables ON CLUSTER).
+  clusterName: ""
+  # MIGRATION_REPLICATED: use replicated history table (ClickHouse).
+  replicated: false
+  # MAX_CONN_ATTEMPTS: connection retries (1-100).
+  maxConnAttempts: 1
+  # COMPACT: compact console output.
+  compact: false
+  # INTERACTIVE is always forced to "false" by the templates: a Job has no TTY and
+  # release/rollback would otherwise block on confirmation prompts.
+  # DRY_RUN: print SQL without executing it.
+  dryRun: false
+  # PLACEHOLDER_CUSTOM: value for the {placeholder_custom} migration placeholder.
+  placeholderCustom: ""
+  # Additional raw env entries appended as-is, e.g. [{name: FOO, value: "bar"}].
+  extraEnv: []
+  # Additional envFrom sources, e.g. [{secretRef: {name: extra}}].
+  extraEnvFrom: []
+
+# release: applies pending migrations. Rendered as a Helm hook so it runs on
+# install/upgrade BEFORE the application pods roll out.
+release:
+  enabled: true
+  # Command passed to db-migrator. Use "release" for atomic batch apply, or "up".
+  command: release
+  # Helm hook phases. pre-* ensures the schema is ready before new app pods start.
+  hookTypes:
+    - pre-install
+    - pre-upgrade
+  weight: "5"
+  deletePolicy: before-hook-creation
+  # Extra annotations merged onto the Job. werf-friendly default; ignored by plain Helm.
+  annotations:
+    werf.io/fail-mode: FailWholeDeployProcessImmediately
+
+# rollback: reverts the latest release batch. Opt-in only (disabled by default) and
+# rendered as a plain Job (NOT a lifecycle hook), so it never runs automatically.
+# Enable it explicitly to perform a rollback (e.g. --set rollback.enabled=true), which
+# works under both werf converge and plain Helm.
+rollback:
+  enabled: false
+  command: rollback
+  # Keep empty for a plain Job. Plain-Helm users may set [pre-rollback] to turn it into
+  # a hook that fires on `helm rollback` (does not fire under werf converge).
+  hookTypes: []
+  weight: "5"
+  deletePolicy: before-hook-creation
+  annotations: {}
+
+# Job / pod spec.
+backoffLimit: 0
+activeDeadlineSeconds: 3600
+ttlSecondsAfterFinished: 30
+restartPolicy: Never
+resources: {}
+podAnnotations: {}
+podLabels: {}
+podSecurityContext: {}
+securityContext: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+serviceAccount:
+  create: false
+  name: ""
+  annotations: {}
+
+# Migration delivery flexibility for non-image variants (ConfigMap/PVC/git-sync).
+# These pass through untouched into the pod spec.
+initContainers: []
+extraVolumes: []
+extraVolumeMounts: []


### PR DESCRIPTION
Adds a reusable Helm chart (`charts/db-migrator`) that runs the tool as a Kubernetes Job.

- **release** — applies pending migrations via a `pre-install,pre-upgrade` hook (schema ready before app pods).
- **rollback** — reverts the latest batch; opt-in plain Job, so it works under both plain Helm and werf.
- DSN referenced from an existing Secret; `INTERACTIVE` forced to `false`.
- Migrations delivered via a custom image (default) or `extraVolumes`/`initContainers` passthrough.
- Usable standalone or as a subchart dependency.

Also: `make helm-lint`/`helm-template`/`helm-package` targets and a `chart-releaser` workflow.

Verified with `helm lint` and `helm template` (both Jobs, hook annotations, secretKeyRef, required DSN).

Note: the release workflow needs one-time setup (a `gh-pages` branch + GitHub Pages enabled).