### PR TITLE
ci: add goreleaser release pipeline with homebrew cask

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Full history + tags are required for the changelog and version detection.
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          # Provided automatically by Actions; grants access to create the release
+          # and upload assets to this repository.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT (repo scope) that can push the generated formula to raoptimus/homebrew-tap.
+          # Create the secret in repo settings; without it the brews step fails.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 !.github
 !.docker
 !.helmignore
+!.goreleaser.yaml
 *.md
 !README.md
 build.sh
 docs
+dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,131 @@
+# GoReleaser configuration.
+# Docs: https://goreleaser.com
+# Release is triggered by pushing a SemVer tag (vX.Y.Z); see .github/workflows/release.yml.
+version: 2
+
+project_name: db-migrator
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: db-migrator
+    main: ./cmd/db-migrator
+    binary: db-migrator
+    env:
+      # Static binary: required for reliable cross-compilation (arm64/windows)
+      # and matches the Makefile `build` target.
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    # Inject version into the same symbols the Makefile uses (main.Version / main.GitCommit),
+    # so `db-migrator version` reports vX.Y.Z.rev[shortsha] in released binaries too.
+    ldflags:
+      - -s -w
+      - -X main.Version={{ .Tag }}
+      - -X main.GitCommit={{ .ShortCommit }}
+
+archives:
+  - id: default
+    formats: [tar.gz]
+    # Windows users expect .zip
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: "checksums.txt"
+
+# Linux packages: .deb / .rpm / .apk built from the same binary via nfpm.
+# Metadata mirrors scripts/debian/control and LICENSE.
+nfpms:
+  - id: packages
+    package_name: db-migrator
+    vendor: raoptimus
+    maintainer: Urvantsev Evgenii <resmus@gmail.com>
+    homepage: https://github.com/raoptimus/db-migrator.go
+    description: CLI tool for managing database migrations (ClickHouse, PostgreSQL, MySQL, Tarantool, Iceberg).
+    license: BSD-3-Clause
+    section: base
+    priority: optional
+    formats:
+      - deb
+      - rpm
+      - apk
+    # Install to /usr/bin so the binary is on PATH out of the box
+    # (the legacy Makefile deb installed to /opt/bin).
+    bindir: /usr/bin
+
+# Homebrew Cask published to the raoptimus/homebrew-tap repository on each release.
+# Requires:
+#   1. An existing repo github.com/raoptimus/homebrew-tap
+#   2. A GitHub PAT (Contents: read/write on that repo) stored as the
+#      HOMEBREW_TAP_GITHUB_TOKEN secret, since the default GITHUB_TOKEN cannot
+#      push to another repository.
+homebrew_casks:
+  - name: db-migrator
+    repository:
+      owner: raoptimus
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/raoptimus/db-migrator.go
+    description: CLI tool for managing database migrations (ClickHouse, PostgreSQL, MySQL, Tarantool, Iceberg).
+    # Skip the tap commit for pre-releases (e.g. v1.2.3-beta.1).
+    skip_upload: auto
+    commit_author:
+      name: goreleaser-bot
+      email: bot@raoptimus.dev
+    # Remove the macOS quarantine attribute so the unsigned binary runs without
+    # a Gatekeeper prompt after `brew install`.
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/db-migrator"]
+          end
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  # Build release notes from Conventional Commits, matching the project's commit style.
+  use: github
+  sort: asc
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: Bug fixes
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: Performance
+      regexp: '^.*?perf(\(.+\))??!?:.+$'
+      order: 2
+    - title: Others
+      order: 999
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^ci:'
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: raoptimus
+    name: db-migrator.go
+  # Mark pre-release automatically for tags like v1.2.3-beta.1
+  prerelease: auto

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 [![Test](https://github.com/raoptimus/db-migrator.go/workflows/Test/badge.svg)](https://github.com/raoptimus/db-migrator.go/actions)
 [![Coverage](https://github.com/raoptimus/db-migrator.go/wiki/coverage.svg)](https://raw.githack.com/wiki/raoptimus/db-migrator.go/coverage.html)
 [![GitHub Release](https://img.shields.io/github/release/raoptimus/db-migrator.go.svg)](https://github.com/raoptimus/db-migrator.go/releases)
+[![Go Reference](https://pkg.go.dev/badge/github.com/raoptimus/db-migrator.go.svg)](https://pkg.go.dev/github.com/raoptimus/db-migrator.go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/raoptimus/db-migrator.go)](https://goreportcard.com/report/github.com/raoptimus/db-migrator.go)
+[![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE)
 
 # db-migrator.go
 Database Migration tool in CLI on Golang that allows you to keep track of database changes in terms of database migrations which are version-controlled.
@@ -10,6 +13,43 @@ The db migration tool currently supports the following db drivers:
 - mysql
 - tarantool db
 - apache iceberg (via REST Catalog)
+
+## Installation
+
+### Homebrew (macOS / Linux)
+```bash
+brew install --cask raoptimus/tap/db-migrator
+```
+
+### Debian / Ubuntu (.deb)
+```bash
+# Replace VERSION and ARCH (amd64 or arm64) with the desired release
+curl -sLO https://github.com/raoptimus/db-migrator.go/releases/latest/download/db-migrator_VERSION_linux_amd64.deb
+sudo dpkg -i db-migrator_*.deb
+```
+
+### RHEL / Fedora (.rpm) and Alpine (.apk)
+Download the matching `.rpm` / `.apk` from the
+[latest release](https://github.com/raoptimus/db-migrator.go/releases/latest) and install with
+`rpm -i` / `apk add --allow-untrusted`.
+
+### Pre-built binaries
+Grab a `tar.gz` (or `.zip` for Windows) for your OS/arch from the
+[releases page](https://github.com/raoptimus/db-migrator.go/releases/latest), extract it, and put
+`db-migrator` on your `PATH`.
+
+### Go install
+```bash
+go install github.com/raoptimus/db-migrator.go/cmd/db-migrator@latest
+```
+
+### Docker
+```bash
+docker run --rm -e DSN -e MIGRATION_PATH -v "$PWD/migrations:/migrations" raoptimus/db-migrator:latest up
+```
+
+### Helm (Kubernetes)
+See the reusable chart in [`charts/db-migrator`](charts/db-migrator).
 
 ## Database Connection Examples
 


### PR DESCRIPTION
Adds a GoReleaser-based release pipeline triggered on `v*` tags:

- Cross-platform binaries (linux/darwin/windows × amd64/arm64) + checksums
- `.deb` / `.rpm` / `.apk` via nfpm (installs to `/usr/bin`)
- Homebrew **cask** published to `raoptimus/homebrew-tap` (with macOS quarantine-removal hook)
- Auto changelog from Conventional Commits
- README: install docs + badges (pkg.go.dev, Go Report Card, License)

Verified locally with `goreleaser check` and `goreleaser release --snapshot --clean --skip=publish`: all 6 platforms, packages, version injection (`vX.Y.Z.rev[sha]`) and the cask were produced successfully.

After merge: tag `v1.8.0` on `main` to cut the first automated release.

Note: requires the `HOMEBREW_TAP_GITHUB_TOKEN` repo secret (already configured).