### PR TITLE
fix(helm): derive default image tag as <appVersion>-alpine

### DIFF
--- a/charts/db-migrator/Chart.yaml
+++ b/charts/db-migrator/Chart.yaml
@@ -7,9 +7,10 @@ description: >-
   standalone and as a subchart dependency, under plain Helm and werf.
 type: application
 # Chart version (SemVer). Bump on any chart change.
-version: 0.1.0
-# Version of the db-migrator tool this chart targets; used as the default image tag.
-appVersion: "1.7.0"
+version: 0.1.1
+# Version of the db-migrator tool this chart targets. The default image tag is
+# derived as "<appVersion>-alpine" (see the db-migrator.image helper).
+appVersion: "1.8.0"
 home: https://github.com/raoptimus/db-migrator.go
 sources:
   - https://github.com/raoptimus/db-migrator.go

--- a/charts/db-migrator/templates/_helpers.tpl
+++ b/charts/db-migrator/templates/_helpers.tpl
@@ -61,10 +61,12 @@ Name of the service account to use.
 {{- end }}
 
 {{/*
-Fully qualified image reference. Tag falls back to the chart appVersion.
+Fully qualified image reference. An explicit .Values.image.tag wins; otherwise the
+tag falls back to "<appVersion>-alpine", matching the tags published to Docker Hub
+(the registry only carries "-alpine" tags, no bare version tags).
 */}}
 {{- define "db-migrator.image" -}}
-{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- $tag := .Values.image.tag | default (printf "%s-alpine" .Chart.AppVersion) -}}
 {{- printf "%s:%s" .Values.image.repository $tag -}}
 {{- end }}
 

--- a/charts/db-migrator/values.yaml
+++ b/charts/db-migrator/values.yaml
@@ -4,7 +4,8 @@
 # the migration files (built FROM raoptimus/db-migrator with the migrations COPY'd in).
 image:
   repository: raoptimus/db-migrator
-  # tag "" falls back to .Chart.AppVersion.
+  # Empty tag falls back to "<appVersion>-alpine" (the tag scheme on Docker Hub).
+  # Set an explicit value to override (used verbatim, include the suffix yourself).
   tag: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
The chart defaulted the image tag to a bare `.Chart.AppVersion` (e.g. `1.7.0`), but Docker Hub only publishes `-alpine` tags (`1.7.0-alpine`, `latest`) — so a plain `helm install` hit `ImagePullBackOff`.

Changes:
- `db-migrator.image` helper now derives the tag as `<appVersion>-alpine`; an explicit `image.tag` still wins verbatim.
- `appVersion` -> `1.8.0` (image `1.8.0-alpine` already on Docker Hub).
- chart `version` -> `0.1.1` (required for chart-releaser to publish the change).

Verified with `helm lint` (0 failed) and `helm template`:
- default -> `raoptimus/db-migrator:1.8.0-alpine`
- `--set image.tag=1.9.0-custom` -> `raoptimus/db-migrator:1.9.0-custom`

Note: bumping `version` triggers the chart-releaser workflow on merge, cutting release `db-migrator-0.1.1`.