### PR TITLE
ci: publish multi-arch docker images via goreleaser

### DIFF
--- a/.docker/goreleaser/Dockerfile
+++ b/.docker/goreleaser/Dockerfile
@@ -1,0 +1,9 @@
+# Runtime image used by GoReleaser (see `dockers` in .goreleaser.yaml).
+# GoReleaser places the prebuilt, statically-linked `db-migrator` binary into the
+# build context, so this image just wraps it in a minimal Alpine runtime — no
+# compilation happens here. Built per-arch and combined into a multi-arch manifest.
+FROM alpine:latest
+RUN apk add --no-cache tzdata ca-certificates
+ENV TZ=UTC
+COPY db-migrator /usr/bin/db-migrator
+ENTRYPOINT ["/usr/bin/db-migrator"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,19 @@ jobs:
         with:
           go-version: '1.26'
 
+      # QEMU + Buildx enable cross-arch (linux/arm64) Docker image builds.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,6 +67,54 @@ nfpms:
     # (the legacy Makefile deb installed to /opt/bin).
     bindir: /usr/bin
 
+# Multi-arch Docker images published to Docker Hub (raoptimus/db-migrator).
+# Replaces the manual `make build-docker-image`. Requires buildx + QEMU and a
+# Docker Hub login in the release workflow (DOCKERHUB_USERNAME / DOCKERHUB_TOKEN).
+# One image is built per architecture, then combined into a manifest below.
+dockers:
+  - id: db-migrator-amd64
+    goos: linux
+    goarch: amd64
+    dockerfile: .docker/goreleaser/Dockerfile
+    use: buildx
+    image_templates:
+      - "raoptimus/db-migrator:{{ .Version }}-alpine-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.source=https://github.com/raoptimus/db-migrator.go"
+      - "--label=org.opencontainers.image.licenses=BSD-3-Clause"
+  - id: db-migrator-arm64
+    goos: linux
+    goarch: arm64
+    dockerfile: .docker/goreleaser/Dockerfile
+    use: buildx
+    image_templates:
+      - "raoptimus/db-migrator:{{ .Version }}-alpine-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.source=https://github.com/raoptimus/db-migrator.go"
+      - "--label=org.opencontainers.image.licenses=BSD-3-Clause"
+
+docker_manifests:
+  # Versioned multi-arch tag, e.g. raoptimus/db-migrator:1.8.0-alpine
+  - name_template: "raoptimus/db-migrator:{{ .Version }}-alpine"
+    image_templates:
+      - "raoptimus/db-migrator:{{ .Version }}-alpine-amd64"
+      - "raoptimus/db-migrator:{{ .Version }}-alpine-arm64"
+  # `latest` points at the same arch images, but only for stable releases so a
+  # pre-release (e.g. v1.8.0-beta.1) never overwrites it.
+  - name_template: "raoptimus/db-migrator:latest"
+    skip_push: '{{ if .Prerelease }}true{{ else }}false{{ end }}'
+    image_templates:
+      - "raoptimus/db-migrator:{{ .Version }}-alpine-amd64"
+      - "raoptimus/db-migrator:{{ .Version }}-alpine-arm64"
+
 # Homebrew Cask published to the raoptimus/homebrew-tap repository on each release.
 # Requires:
 #   1. An existing repo github.com/raoptimus/homebrew-tap


### PR DESCRIPTION
Moves Docker image publishing into the GoReleaser release pipeline, replacing the manual `make build-docker-image`.

**What it does (on every `v*` tag):**
- Builds `linux/amd64` + `linux/arm64` images from a minimal Alpine runtime (`.docker/goreleaser/Dockerfile`) that wraps the prebuilt binary — no compile-from-source.
- Pushes a multi-arch manifest `raoptimus/db-migrator:<version>-alpine` (matches the existing Docker Hub tag scheme).
- Updates `latest` **only for stable releases** (pre-releases never overwrite it).
- Adds OCI labels (source, revision, version, license).

**Workflow:** adds QEMU, Buildx and a Docker Hub login step.

**Verified locally** with `goreleaser check` and `goreleaser release --snapshot --clean --skip=publish`: both arch images build and the container runs `db-migrator --version` → `v1.8.0.rev[...]`.

**⚠️ Requires two new repo secrets before the next release:**
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN` (Docker Hub access token with write scope)

Note: uses `dockers`/`docker_manifests` (stable). GoReleaser flags these as eventually-deprecated in favour of `dockers_v2`; deferred because `dockers_v2` uses a different build-context layout and needs more work to get right. `goreleaser check` still passes (soft warning only).