### PR TITLE
fix(iceberg): disable pagination on catalog ping to avoid REST server…

### DIFF
--- a/internal/infrastructure/iceberg/catalog/catalog.go
+++ b/internal/infrastructure/iceberg/catalog/catalog.go
@@ -95,6 +95,10 @@ func (c *Client) Warehouse() string {
 
 // Ping verifies connectivity to the REST catalog by listing top-level namespaces.
 func (c *Client) Ping(ctx context.Context) error {
+	// Disable pagination: the reference Iceberg REST server (iceberg-rest-fixture) throws
+	// NumberFormatException on listNamespaces when a pageSize is sent without a pageToken.
+	// iceberg-go sends pageSize=20 unconditionally, so suppress it to avoid the server bug.
+	ctx = c.cat.SetPageSize(ctx, 0)
 	_, err := c.cat.ListNamespaces(ctx, nil)
 	if err != nil {
 		return errors.WithMessage(err, "ping iceberg catalog")


### PR DESCRIPTION
… NPE

iceberg-go v0.6.0 sends pageSize=20 unconditionally on ListNamespaces. The reference Iceberg REST server (iceberg-rest-fixture) then parses a null pageToken via Integer.parseInt, returning HTTP 500 NumberFormatException on every Ping. Suppress pagination with SetPageSize(ctx, 0) so the pageSize query param is omitted.