### PR TITLE
feat(iceberg): honor IF [NOT] EXISTS and support WRITE ORDERED BY sort order

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,8 +532,15 @@ The supported subset covers the most common schema-evolution DDL (v1):
 | `ALTER TABLE <id> ALTER COLUMN <name> TYPE <type>` | Change a column type (widening only) |
 | `ALTER TABLE <id> ADD PARTITION FIELD <transform>(<col>)` | Add a partition field |
 | `ALTER TABLE <id> DROP PARTITION FIELD <transform>(<col>)` | Drop a partition field |
+| `ALTER TABLE <id> WRITE ORDERED BY <col> [ASC\|DESC] [NULLS FIRST\|LAST], …` | Set the table write sort order |
+| `ALTER TABLE <id> WRITE UNORDERED` | Clear the table write sort order |
 
 SQL comments (`--` and `/* */`) are supported inside migration files.
+
+`WRITE ORDERED BY` accepts plain columns or partition-style transforms (e.g. `bucket(8, id)`,
+`days(ts)`). Direction defaults to `ASC`; null ordering defaults to `NULLS FIRST` for `ASC` and
+`NULLS LAST` for `DESC` (Iceberg convention). Setting a sort order is not automatically
+reversible — a `.down.sql` should restore the previous order explicitly or use `WRITE UNORDERED`.
 
 **Supported column types:**
 

--- a/internal/application/handler/integration_iceberg_test.go
+++ b/internal/application/handler/integration_iceberg_test.go
@@ -1040,6 +1040,146 @@ func TestIntegration_Iceberg_MultiLevelNamespace(t *testing.T) {
 	})
 }
 
+// TestIntegration_Iceberg_IfNotExistsIdempotent reproduces the reported bug where
+// `release` with a duplicate `CREATE TABLE IF NOT EXISTS` failed with AlreadyExistsException,
+// and verifies the whole IF [NOT] EXISTS family is now idempotent end-to-end against the catalog:
+//   - CREATE TABLE IF NOT EXISTS on an existing table is skipped (not an error);
+//   - DROP TABLE IF EXISTS on an already-dropped table is skipped;
+//   - DROP NAMESPACE IF EXISTS drops the namespace.
+func TestIntegration_Iceberg_IfNotExistsIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	loadIcebergEnv(t)
+
+	tmpDir := t.TempDir()
+	write := func(name, content string) {
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0o600))
+	}
+
+	// Namespace (bare name, like the reference fixtures).
+	write("260301_100000_ns.up.sql", "CREATE NAMESPACE IF NOT EXISTS idemp;\n")
+	write("260301_100000_ns.down.sql", "DROP NAMESPACE IF EXISTS idemp;\n")
+	// First table creation. DSN warehouse = iceberg, so the leading segment is stripped:
+	// iceberg.idemp.widgets => namespace=[idemp], table=widgets.
+	write("260301_100100_tbl.up.sql", "CREATE TABLE IF NOT EXISTS iceberg.idemp.widgets (id long);\n")
+	write("260301_100100_tbl.down.sql", "DROP TABLE IF EXISTS iceberg.idemp.widgets;\n")
+	// Duplicate creation of the SAME table: must be skipped idempotently, not fail.
+	write("260301_100200_tbl_dup.up.sql", "CREATE TABLE IF NOT EXISTS iceberg.idemp.widgets (id long);\n")
+	// Its down drops the table; the previous migration's down then hits DROP TABLE IF EXISTS
+	// on an already-dropped table, exercising the idempotent-drop path.
+	write("260301_100200_tbl_dup.down.sql", "DROP TABLE IF EXISTS iceberg.idemp.widgets;\n")
+
+	opts := &Options{
+		DSN:         icebergDSN(),
+		Directory:   tmpDir,
+		TableName:   "mig_ifnotexists",
+		Compact:     true,
+		Interactive: false,
+	}
+	handlers := NewHandlers(opts, &infralog.NopLogger{})
+
+	createCommand := func(arg string) *Command {
+		args := NewMockArgs(t)
+		args.EXPECT().First().Return(arg).Maybe()
+		args.EXPECT().Present().Return(true).Maybe()
+		return &Command{Args: args}
+	}
+
+	conn, err := connection.Try(opts.DSN, 1)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	repo, err := repository.New(conn, &repository.Options{TableName: opts.TableName})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("release_with_duplicate_create_table_is_idempotent", func(t *testing.T) {
+		cleanupIceberg(handlers, createCommand)
+		defer func() { cleanupIceberg(handlers, createCommand) }()
+
+		// release applies all three migrations in one batch. The duplicate
+		// CREATE TABLE IF NOT EXISTS must be skipped, not raise AlreadyExistsException.
+		err = handlers.Release.Handle(createCommand(""))
+		require.NoError(t, err, "duplicate CREATE TABLE IF NOT EXISTS must be skipped, not fail")
+		assertIcebergMigrationsCount(t, ctx, repo, 4) // base + 3
+
+		// down all reverts in reverse order; the second DROP TABLE IF EXISTS lands on an
+		// already-dropped table (idempotent skip), then DROP NAMESPACE IF EXISTS removes it.
+		err = handlers.Downgrade.Handle(createCommand("all"))
+		require.NoError(t, err)
+		assertIcebergMigrationsCount(t, ctx, repo, 1) // base only
+	})
+}
+
+// TestIntegration_Iceberg_WriteOrderedBy verifies the ALTER TABLE … WRITE ORDERED BY / WRITE
+// UNORDERED sort-order operations end-to-end against the real catalog: a sort order with a plain
+// column and a transform is committed via CommitTable, and the down migration resets it with
+// WRITE UNORDERED.
+func TestIntegration_Iceberg_WriteOrderedBy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	loadIcebergEnv(t)
+
+	tmpDir := t.TempDir()
+	write := func(name, content string) {
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0o600))
+	}
+
+	write("260401_100000_ns.up.sql", "CREATE NAMESPACE IF NOT EXISTS sortns;\n")
+	write("260401_100000_ns.down.sql", "DROP NAMESPACE IF EXISTS sortns;\n")
+	write("260401_100100_tbl.up.sql",
+		"CREATE TABLE iceberg.sortns.orders (id long, amount long, created_at timestamp);\n")
+	write("260401_100100_tbl.down.sql", "DROP TABLE IF EXISTS iceberg.sortns.orders;\n")
+	// Sort order over a plain column (with explicit null ordering) and a bucket transform.
+	write("260401_100200_sort.up.sql",
+		"ALTER TABLE iceberg.sortns.orders WRITE ORDERED BY created_at DESC NULLS LAST, bucket(8, id);\n")
+	// Reverting a sort order is not automatic — reset to unsorted.
+	write("260401_100200_sort.down.sql", "ALTER TABLE iceberg.sortns.orders WRITE UNORDERED;\n")
+
+	opts := &Options{
+		DSN:         icebergDSN(),
+		Directory:   tmpDir,
+		TableName:   "mig_sortorder",
+		Compact:     true,
+		Interactive: false,
+	}
+	handlers := NewHandlers(opts, &infralog.NopLogger{})
+
+	createCommand := func(arg string) *Command {
+		args := NewMockArgs(t)
+		args.EXPECT().First().Return(arg).Maybe()
+		args.EXPECT().Present().Return(true).Maybe()
+		return &Command{Args: args}
+	}
+
+	conn, err := connection.Try(opts.DSN, 1)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	repo, err := repository.New(conn, &repository.Options{TableName: opts.TableName})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("apply_sort_order_and_reset", func(t *testing.T) {
+		cleanupIceberg(handlers, createCommand)
+		defer func() { cleanupIceberg(handlers, createCommand) }()
+
+		// up applies namespace + table + WRITE ORDERED BY (commits sort order via CommitTable).
+		err = handlers.Upgrade.Handle(createCommand(""))
+		require.NoError(t, err, "WRITE ORDERED BY must commit the sort order successfully")
+		assertIcebergMigrationsCount(t, ctx, repo, 4) // base + 3
+
+		// down all reverts: WRITE UNORDERED (reset), DROP TABLE, DROP NAMESPACE.
+		err = handlers.Downgrade.Handle(createCommand("all"))
+		require.NoError(t, err)
+		assertIcebergMigrationsCount(t, ctx, repo, 1) // base only
+	})
+}
+
 // Compile-time verification that *testCapturingLogger satisfies Logger.
 // Uses the Logger type alias defined in dependency.go (= log.Logger interface).
 var _ Logger = (*testCapturingLogger)(nil)

--- a/internal/infrastructure/dal/repository/dependency.go
+++ b/internal/infrastructure/dal/repository/dependency.go
@@ -33,6 +33,8 @@ type IcebergCatalog interface {
 
 	// CreateTable creates an Iceberg table from the given IR specification.
 	CreateTable(ctx context.Context, ident ddl.Ident, spec ddl.CreateTableSpec) error
+	// TableExists checks whether the given table exists in the catalog.
+	TableExists(ctx context.Context, ident ddl.Ident) (bool, error)
 	// DropTable drops an Iceberg table identified by ident.
 	DropTable(ctx context.Context, ident ddl.Ident) error
 	// RenameTable renames an Iceberg table from from to to.
@@ -43,6 +45,9 @@ type IcebergCatalog interface {
 	// ApplySpecChange applies a partition-spec DDL operation (AddPartitionField,
 	// DropPartitionField) via an Iceberg spec update transaction.
 	ApplySpecChange(ctx context.Context, op ddl.Operation) error
+	// ApplySortOrderChange sets or clears the table write sort order (WRITE ORDERED BY /
+	// WRITE UNORDERED) via a catalog CommitTable call.
+	ApplySortOrderChange(ctx context.Context, op ddl.Operation) error
 }
 
 //go:generate mockery

--- a/internal/infrastructure/dal/repository/iceberg.go
+++ b/internal/infrastructure/dal/repository/iceberg.go
@@ -210,13 +210,40 @@ func (i *Iceberg) ExecQuery(ctx context.Context, query string, _ ...any) error {
 		}
 		return i.cat.CreateNamespace(ctx, op.Table.Namespace, op.Props)
 	case ddl.DropNamespace:
+		if op.IfExists {
+			exists, err := i.cat.NamespaceExists(ctx, op.Table.Namespace)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return nil
+			}
+		}
 		return i.cat.DropNamespace(ctx, op.Table.Namespace)
 	case ddl.CreateTable:
 		if op.Create == nil {
 			return errors.New("iceberg: CreateTable IR has nil Create spec")
 		}
+		if op.IfNotExists {
+			exists, err := i.cat.TableExists(ctx, op.Table)
+			if err != nil {
+				return err
+			}
+			if exists {
+				return nil
+			}
+		}
 		return i.cat.CreateTable(ctx, op.Table, *op.Create)
 	case ddl.DropTable:
+		if op.IfExists {
+			exists, err := i.cat.TableExists(ctx, op.Table)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return nil
+			}
+		}
 		return i.cat.DropTable(ctx, op.Table)
 	case ddl.RenameTable:
 		if op.RenameTo == nil {
@@ -227,6 +254,8 @@ func (i *Iceberg) ExecQuery(ctx context.Context, query string, _ ...any) error {
 		return i.cat.ApplySchemaChange(ctx, op)
 	case ddl.AddPartitionField, ddl.DropPartitionField:
 		return i.cat.ApplySpecChange(ctx, op)
+	case ddl.SetSortOrder:
+		return i.cat.ApplySortOrderChange(ctx, op)
 	default:
 		return errors.WithStack(ddl.ErrUnsupportedDDL)
 	}

--- a/internal/infrastructure/dal/repository/iceberg_catalog_mock_test.go
+++ b/internal/infrastructure/dal/repository/iceberg_catalog_mock_test.go
@@ -69,6 +69,53 @@ func (_c *MockIcebergCatalog_ApplySchemaChange_Call) RunAndReturn(run func(conte
 	return _c
 }
 
+// ApplySortOrderChange provides a mock function with given fields: ctx, op
+func (_m *MockIcebergCatalog) ApplySortOrderChange(ctx context.Context, op ddl.Operation) error {
+	ret := _m.Called(ctx, op)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ApplySortOrderChange")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, ddl.Operation) error); ok {
+		r0 = rf(ctx, op)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockIcebergCatalog_ApplySortOrderChange_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ApplySortOrderChange'
+type MockIcebergCatalog_ApplySortOrderChange_Call struct {
+	*mock.Call
+}
+
+// ApplySortOrderChange is a helper method to define mock.On call
+//   - ctx context.Context
+//   - op ddl.Operation
+func (_e *MockIcebergCatalog_Expecter) ApplySortOrderChange(ctx interface{}, op interface{}) *MockIcebergCatalog_ApplySortOrderChange_Call {
+	return &MockIcebergCatalog_ApplySortOrderChange_Call{Call: _e.mock.On("ApplySortOrderChange", ctx, op)}
+}
+
+func (_c *MockIcebergCatalog_ApplySortOrderChange_Call) Run(run func(ctx context.Context, op ddl.Operation)) *MockIcebergCatalog_ApplySortOrderChange_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(ddl.Operation))
+	})
+	return _c
+}
+
+func (_c *MockIcebergCatalog_ApplySortOrderChange_Call) Return(_a0 error) *MockIcebergCatalog_ApplySortOrderChange_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockIcebergCatalog_ApplySortOrderChange_Call) RunAndReturn(run func(context.Context, ddl.Operation) error) *MockIcebergCatalog_ApplySortOrderChange_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ApplySpecChange provides a mock function with given fields: ctx, op
 func (_m *MockIcebergCatalog) ApplySpecChange(ctx context.Context, op ddl.Operation) error {
 	ret := _m.Called(ctx, op)
@@ -557,6 +604,63 @@ func (_c *MockIcebergCatalog_RenameTable_Call) Return(_a0 error) *MockIcebergCat
 }
 
 func (_c *MockIcebergCatalog_RenameTable_Call) RunAndReturn(run func(context.Context, ddl.Ident, ddl.Ident) error) *MockIcebergCatalog_RenameTable_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// TableExists provides a mock function with given fields: ctx, ident
+func (_m *MockIcebergCatalog) TableExists(ctx context.Context, ident ddl.Ident) (bool, error) {
+	ret := _m.Called(ctx, ident)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TableExists")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, ddl.Ident) (bool, error)); ok {
+		return rf(ctx, ident)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, ddl.Ident) bool); ok {
+		r0 = rf(ctx, ident)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, ddl.Ident) error); ok {
+		r1 = rf(ctx, ident)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockIcebergCatalog_TableExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TableExists'
+type MockIcebergCatalog_TableExists_Call struct {
+	*mock.Call
+}
+
+// TableExists is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ident ddl.Ident
+func (_e *MockIcebergCatalog_Expecter) TableExists(ctx interface{}, ident interface{}) *MockIcebergCatalog_TableExists_Call {
+	return &MockIcebergCatalog_TableExists_Call{Call: _e.mock.On("TableExists", ctx, ident)}
+}
+
+func (_c *MockIcebergCatalog_TableExists_Call) Run(run func(ctx context.Context, ident ddl.Ident)) *MockIcebergCatalog_TableExists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(ddl.Ident))
+	})
+	return _c
+}
+
+func (_c *MockIcebergCatalog_TableExists_Call) Return(_a0 bool, _a1 error) *MockIcebergCatalog_TableExists_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockIcebergCatalog_TableExists_Call) RunAndReturn(run func(context.Context, ddl.Ident) (bool, error)) *MockIcebergCatalog_TableExists_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/infrastructure/dal/repository/iceberg_test.go
+++ b/internal/infrastructure/dal/repository/iceberg_test.go
@@ -752,6 +752,26 @@ func TestIceberg_ExecQuery_Dispatch(t *testing.T) {
 					Return(nil).Once()
 			},
 		},
+		{
+			name:  "WRITE ORDERED BY → ApplySortOrderChange",
+			query: "ALTER TABLE analytics.events WRITE ORDERED BY event_time DESC, user_id",
+			setup: func(cat *MockIcebergCatalog) {
+				cat.EXPECT().Warehouse().Return("").Once()
+				cat.EXPECT().
+					ApplySortOrderChange(ctx, mock.AnythingOfType("ddl.Operation")).
+					Return(nil).Once()
+			},
+		},
+		{
+			name:  "WRITE UNORDERED → ApplySortOrderChange",
+			query: "ALTER TABLE analytics.events WRITE UNORDERED",
+			setup: func(cat *MockIcebergCatalog) {
+				cat.EXPECT().Warehouse().Return("").Once()
+				cat.EXPECT().
+					ApplySortOrderChange(ctx, mock.AnythingOfType("ddl.Operation")).
+					Return(nil).Once()
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -806,6 +826,109 @@ func TestIceberg_ExecQuery_CreateNamespaceIfNotExists(t *testing.T) {
 		err := repo.ExecQuery(ctx, "CREATE NAMESPACE IF NOT EXISTS analytics")
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "catalog unreachable")
+	})
+}
+
+// TestIceberg_ExecQuery_CreateTableIfNotExists verifies idempotent table creation:
+// CREATE TABLE IF NOT EXISTS skips CreateTable when the table already exists (checked via
+// TableExists), calls CreateTable exactly once when it does not, and propagates a TableExists error.
+// A plain CREATE TABLE (without the flag) must NOT probe existence.
+func TestIceberg_ExecQuery_CreateTableIfNotExists(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("table exists → CreateTable skipped", func(t *testing.T) {
+		repo, cat := newIcebergRepo(t)
+		cat.EXPECT().Warehouse().Return("").Once()
+		cat.EXPECT().
+			TableExists(ctx, mock.AnythingOfType("ddl.Ident")).
+			Return(true, nil).Once()
+		// No CreateTable expectation: the mock fails if it is called.
+
+		err := repo.ExecQuery(ctx, "CREATE TABLE IF NOT EXISTS analytics.events (id long)")
+		require.NoError(t, err)
+	})
+
+	t.Run("table missing → CreateTable called once", func(t *testing.T) {
+		repo, cat := newIcebergRepo(t)
+		cat.EXPECT().Warehouse().Return("").Once()
+		cat.EXPECT().
+			TableExists(ctx, mock.AnythingOfType("ddl.Ident")).
+			Return(false, nil).Once()
+		cat.EXPECT().
+			CreateTable(ctx, mock.AnythingOfType("ddl.Ident"), mock.AnythingOfType("ddl.CreateTableSpec")).
+			Return(nil).Once()
+
+		err := repo.ExecQuery(ctx, "CREATE TABLE IF NOT EXISTS analytics.events (id long)")
+		require.NoError(t, err)
+	})
+
+	t.Run("TableExists error is propagated", func(t *testing.T) {
+		repo, cat := newIcebergRepo(t)
+		cat.EXPECT().Warehouse().Return("").Once()
+		cat.EXPECT().
+			TableExists(ctx, mock.AnythingOfType("ddl.Ident")).
+			Return(false, errors.New("catalog unreachable")).Once()
+
+		err := repo.ExecQuery(ctx, "CREATE TABLE IF NOT EXISTS analytics.events (id long)")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "catalog unreachable")
+	})
+
+	t.Run("plain CREATE TABLE does not probe existence", func(t *testing.T) {
+		repo, cat := newIcebergRepo(t)
+		cat.EXPECT().Warehouse().Return("").Once()
+		// No TableExists expectation: the mock fails if existence is probed.
+		cat.EXPECT().
+			CreateTable(ctx, mock.AnythingOfType("ddl.Ident"), mock.AnythingOfType("ddl.CreateTableSpec")).
+			Return(nil).Once()
+
+		err := repo.ExecQuery(ctx, "CREATE TABLE analytics.events (id long)")
+		require.NoError(t, err)
+	})
+}
+
+// TestIceberg_ExecQuery_DropIfExists verifies idempotent drops:
+// DROP TABLE IF EXISTS and DROP NAMESPACE IF EXISTS skip the drop when the object is absent, and
+// perform it when present. Plain drops (without the flag) must NOT probe existence.
+func TestIceberg_ExecQuery_DropIfExists(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("DROP TABLE IF EXISTS, table missing → DropTable skipped", func(t *testing.T) {
+		repo, cat := newIcebergRepo(t)
+		cat.EXPECT().Warehouse().Return("").Once()
+		cat.EXPECT().
+			TableExists(ctx, mock.AnythingOfType("ddl.Ident")).
+			Return(false, nil).Once()
+		// No DropTable expectation: the mock fails if it is called.
+
+		err := repo.ExecQuery(ctx, "DROP TABLE IF EXISTS analytics.events")
+		require.NoError(t, err)
+	})
+
+	t.Run("DROP TABLE IF EXISTS, table present → DropTable called once", func(t *testing.T) {
+		repo, cat := newIcebergRepo(t)
+		cat.EXPECT().Warehouse().Return("").Once()
+		cat.EXPECT().
+			TableExists(ctx, mock.AnythingOfType("ddl.Ident")).
+			Return(true, nil).Once()
+		cat.EXPECT().
+			DropTable(ctx, mock.AnythingOfType("ddl.Ident")).
+			Return(nil).Once()
+
+		err := repo.ExecQuery(ctx, "DROP TABLE IF EXISTS analytics.events")
+		require.NoError(t, err)
+	})
+
+	t.Run("DROP NAMESPACE IF EXISTS, namespace missing → DropNamespace skipped", func(t *testing.T) {
+		repo, cat := newIcebergRepo(t)
+		cat.EXPECT().Warehouse().Return("").Once()
+		cat.EXPECT().
+			NamespaceExists(ctx, []string{"analytics"}).
+			Return(false, nil).Once()
+		// No DropNamespace expectation: the mock fails if it is called.
+
+		err := repo.ExecQuery(ctx, "DROP NAMESPACE IF EXISTS analytics")
+		require.NoError(t, err)
 	})
 }
 

--- a/internal/infrastructure/iceberg/catalog/catalog.go
+++ b/internal/infrastructure/iceberg/catalog/catalog.go
@@ -37,6 +37,13 @@ import (
 type Client struct {
 	cat       *rest.Catalog
 	warehouse string // warehouse name extracted from DSN path (used for catalog-prefix stripping)
+
+	// headUnsupported is set to true once the REST server is observed to reject a HEAD
+	// existence probe with a definitive "bad request" (older JdbcCatalog builds do not
+	// implement HEAD; see the namespace GET-over-HEAD fix). After that, TableExists falls
+	// back to the GET-based ListTables path for the rest of the process. Migrations run
+	// sequentially, so a plain bool without synchronization is sufficient.
+	headUnsupported bool
 }
 
 // New constructs a REST catalog client from a parsed DSN.

--- a/internal/infrastructure/iceberg/catalog/table.go
+++ b/internal/infrastructure/iceberg/catalog/table.go
@@ -14,6 +14,7 @@ import (
 
 	iceberg "github.com/apache/iceberg-go"
 	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	"github.com/apache/iceberg-go/catalog/rest"
 	"github.com/apache/iceberg-go/table"
 	"github.com/pkg/errors"
 	"github.com/raoptimus/db-migrator.go/internal/infrastructure/iceberg/ddl"
@@ -68,6 +69,42 @@ func (c *Client) CreateTable(ctx context.Context, id ddl.Ident, spec ddl.CreateT
 		return errors.WithMessage(err, "create table")
 	}
 	return nil
+}
+
+// TableExists reports whether the given table exists in the catalog.
+//
+// It prefers a single lightweight HEAD probe (CheckTableExists), which touches neither
+// S3 nor table metadata. Older REST servers (JdbcCatalog builds) do not implement HEAD
+// and reject it with 400; on that definitive signal we permanently switch to the
+// GET-based ListTables path for the rest of the process (same reasoning as the namespace
+// GET-over-HEAD fix). Transient HEAD errors trigger a one-off fallback without disabling
+// HEAD for later probes.
+func (c *Client) TableExists(ctx context.Context, id ddl.Ident) (bool, error) {
+	if !c.headUnsupported {
+		exists, err := c.cat.CheckTableExists(ctx, ident(id))
+		if err == nil {
+			return exists, nil
+		}
+		if errors.Is(err, rest.ErrBadRequest) {
+			// HEAD unsupported by this server — stop probing with HEAD for the rest of the run.
+			c.headUnsupported = true
+		}
+		// Fall through to the GET-based path for this call regardless of error kind.
+	}
+
+	// GET fallback: list tables in the namespace (no S3, no metadata read) and match by name.
+	// SetPageSize(0) suppresses the unconditional pageSize query param that trips a
+	// NumberFormatException on the reference REST server (see Ping).
+	ctx = c.cat.SetPageSize(ctx, 0)
+	for tbl, err := range c.cat.ListTables(ctx, id.Namespace) {
+		if err != nil {
+			return false, errors.WithMessage(err, "check table exists")
+		}
+		if len(tbl) > 0 && tbl[len(tbl)-1] == id.Table {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // DropTable drops an Iceberg table.
@@ -203,6 +240,81 @@ func (c *Client) ApplySpecChange(ctx context.Context, op ddl.Operation) error {
 		return errors.WithMessage(err, "persist spec change")
 	}
 	return nil
+}
+
+// ApplySortOrderChange sets (or clears) a table's write sort order.
+//
+// iceberg-go v0.6.0 has no high-level sort-order transaction builder (unlike UpdateSpec /
+// UpdateSchema), so the change is applied through the exported catalog-level CommitTable with
+// AddSortOrder + SetDefaultSortOrder updates, guarded by an AssertTableUUID requirement for
+// optimistic concurrency. WRITE UNORDERED resets the default to the always-present unsorted
+// order (id 0).
+//
+//nolint:gocritic // hugeParam: op is passed by value to match the IcebergCatalog interface contract
+func (c *Client) ApplySortOrderChange(ctx context.Context, op ddl.Operation) error {
+	if op.Sort == nil {
+		return errors.New("SetSortOrder: sort spec is nil")
+	}
+	tbl, err := c.cat.LoadTable(ctx, ident(op.Table))
+	if err != nil {
+		return errors.WithMessage(err, "load table for sort order change")
+	}
+
+	var updates []table.Update
+	if op.Sort.Unordered {
+		updates = []table.Update{table.NewSetDefaultSortOrderUpdate(table.UnsortedSortOrderID)}
+	} else {
+		schema := tbl.Schema()
+		fields := make([]table.SortField, 0, len(op.Sort.Fields))
+		for _, sf := range op.Sort.Fields {
+			col, ok := schema.FindFieldByName(sf.SourceCol)
+			if !ok {
+				return errors.Errorf("sort column %q not found in table schema", sf.SourceCol)
+			}
+			transform, err := toIcebergTransform(sf.Transform, sf.Param)
+			if err != nil {
+				return errors.WithMessagef(err, "map transform for sort column %s", sf.SourceCol)
+			}
+			fields = append(fields, table.SortField{
+				SourceIDs: []int{col.ID},
+				Transform: transform,
+				Direction: toIcebergSortDirection(sf.Direction),
+				NullOrder: toIcebergNullOrder(sf.NullOrder),
+			})
+		}
+		so, err := table.NewSortOrder(table.InitialSortOrderID, fields)
+		if err != nil {
+			return errors.WithMessage(err, "build sort order")
+		}
+		// SetDefaultSortOrder(-1) points the default at the just-added order (its final id is
+		// assigned server-side / by the metadata builder).
+		updates = []table.Update{
+			table.NewAddSortOrderUpdate(&so),
+			table.NewSetDefaultSortOrderUpdate(-1),
+		}
+	}
+
+	reqs := []table.Requirement{table.AssertTableUUID(tbl.Metadata().TableUUID())}
+	if _, _, err := c.cat.CommitTable(ctx, ident(op.Table), reqs, updates); err != nil {
+		return errors.WithMessage(err, "commit sort order")
+	}
+	return nil
+}
+
+// toIcebergSortDirection maps a ddl.SortDirection to iceberg-go's table.SortDirection.
+func toIcebergSortDirection(d ddl.SortDirection) table.SortDirection {
+	if d == ddl.SortDesc {
+		return table.SortDESC
+	}
+	return table.SortASC
+}
+
+// toIcebergNullOrder maps a ddl.NullOrder to iceberg-go's table.NullOrder.
+func toIcebergNullOrder(n ddl.NullOrder) table.NullOrder {
+	if n == ddl.NullsLast {
+		return table.NullsLast
+	}
+	return table.NullsFirst
 }
 
 // ─── schema building ────────────────────────────────────────────────────────

--- a/internal/infrastructure/iceberg/ddl/ir.go
+++ b/internal/infrastructure/iceberg/ddl/ir.go
@@ -15,6 +15,7 @@ const (
 	AlterColumnType                  // ALTER TABLE … ALTER COLUMN … TYPE
 	AddPartitionField                // ALTER TABLE … ADD PARTITION FIELD
 	DropPartitionField               // ALTER TABLE … DROP PARTITION FIELD
+	SetSortOrder                     // ALTER TABLE … WRITE ORDERED BY … / WRITE UNORDERED
 )
 
 // Ident is a fully-qualified table or namespace identifier with the catalog prefix already stripped.
@@ -35,7 +36,9 @@ type Operation struct {
 	Partition   *PartitionField   // AddPartitionField / DropPartitionField
 	Create      *CreateTableSpec  // CreateTable: full table specification
 	Props       map[string]string // CreateNamespace: optional properties
-	IfNotExists bool              // CreateNamespace: skip if the namespace already exists
+	IfNotExists bool              // CreateNamespace / CreateTable: skip creation if the object already exists
+	IfExists    bool              // DropNamespace / DropTable: skip drop if the object does not exist
+	Sort        *SortSpec         // SetSortOrder: sort order specification (WRITE ORDERED BY / WRITE UNORDERED)
 }
 
 // CreateTableSpec holds the full specification of a CREATE TABLE statement.
@@ -104,4 +107,39 @@ type PartitionField struct {
 	Param     int    // Bucket / Truncate: N
 	SourceCol string // source column name
 	Name      string // optional explicit partition field name
+}
+
+// SortDirection is the ordering direction of a sort field.
+type SortDirection int
+
+const (
+	SortAsc  SortDirection = iota // ASC (default)
+	SortDesc                      // DESC
+)
+
+// NullOrder is the placement of NULL values within a sort field.
+type NullOrder int
+
+const (
+	NullsFirst NullOrder = iota // NULLS FIRST
+	NullsLast                   // NULLS LAST
+)
+
+// SortField describes a single column of a table write sort order, including its transform,
+// direction, and null ordering. The transform reuses the partition TransformKind vocabulary
+// (Identity for a plain column, plus bucket/truncate/years/months/days/hours).
+type SortField struct {
+	Transform TransformKind
+	Param     int    // Bucket / Truncate: N
+	SourceCol string // source column name
+	Direction SortDirection
+	NullOrder NullOrder
+}
+
+// SortSpec holds the target write sort order for a SetSortOrder operation.
+// Unordered is true for WRITE UNORDERED (clear the sort order); otherwise Fields holds the
+// ordered list of sort columns from WRITE ORDERED BY.
+type SortSpec struct {
+	Unordered bool
+	Fields    []SortField
 }

--- a/internal/infrastructure/iceberg/ddl/parse.go
+++ b/internal/infrastructure/iceberg/ddl/parse.go
@@ -176,6 +176,18 @@ func (p *parser) consumeIfNotExists() (bool, error) {
 	return true, nil
 }
 
+// consumeIfExists consumes an optional "IF EXISTS" clause and reports whether it was present.
+func (p *parser) consumeIfExists() (bool, error) {
+	if !p.peekUpperIs("IF") {
+		return false, nil
+	}
+	p.consume()
+	if err := p.expectConsume("EXISTS"); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func (p *parser) parseCreateNamespace() (Operation, error) {
 	p.mustConsume(kwNAMESPACE)
 	ifNotExists, err := p.consumeIfNotExists()
@@ -197,7 +209,8 @@ func (p *parser) parseCreateNamespace() (Operation, error) {
 
 func (p *parser) parseCreateTable() (Operation, error) {
 	p.mustConsume(kwTABLE)
-	if _, err := p.consumeIfNotExists(); err != nil {
+	ifNotExists, err := p.consumeIfNotExists()
+	if err != nil {
 		return Operation{}, err
 	}
 	id, err := p.parseIdent()
@@ -263,9 +276,10 @@ func (p *parser) parseCreateTable() (Operation, error) {
 	}
 done:
 	return Operation{
-		Kind:   CreateTable,
-		Table:  id,
-		Create: spec,
+		Kind:        CreateTable,
+		Table:       id,
+		Create:      spec,
+		IfNotExists: ifNotExists,
 	}, nil
 }
 
@@ -461,30 +475,32 @@ func (p *parser) parseDrop() (Operation, error) {
 
 func (p *parser) parseDropNamespace() (Operation, error) {
 	p.mustConsume(kwNAMESPACE)
+	ifExists, err := p.consumeIfExists()
+	if err != nil {
+		return Operation{}, err
+	}
 	ns, err := p.parseNamespaceIdent()
 	if err != nil {
 		return Operation{}, err
 	}
 	return Operation{
-		Kind:  DropNamespace,
-		Table: Ident{Namespace: ns},
+		Kind:     DropNamespace,
+		Table:    Ident{Namespace: ns},
+		IfExists: ifExists,
 	}, nil
 }
 
 func (p *parser) parseDropTable() (Operation, error) {
 	p.mustConsume(kwTABLE)
-	// Optional IF EXISTS
-	if p.peekUpperIs("IF") {
-		p.consume()
-		if err := p.expectConsume("EXISTS"); err != nil {
-			return Operation{}, err
-		}
+	ifExists, err := p.consumeIfExists()
+	if err != nil {
+		return Operation{}, err
 	}
 	id, err := p.parseIdent()
 	if err != nil {
 		return Operation{}, err
 	}
-	return Operation{Kind: DropTable, Table: id}, nil
+	return Operation{Kind: DropTable, Table: id, IfExists: ifExists}, nil
 }
 
 // ─── RENAME ────────────────────────────────────────────────────────────────────
@@ -544,9 +560,134 @@ func (p *parser) parseAlter() (Operation, error) {
 		return p.parseAlterRename(id)
 	case kwALTER:
 		return p.parseAlterColumn(id)
+	case "WRITE":
+		return p.parseAlterWrite(id)
 	default:
 		return Operation{}, errors.Wrapf(ErrUnsupportedDDL, "ALTER TABLE … %s is not supported: %s", sub, p.stmt)
 	}
+}
+
+// parseAlterWrite handles WRITE ORDERED BY … and WRITE UNORDERED (table write sort order).
+func (p *parser) parseAlterWrite(id Ident) (Operation, error) {
+	p.mustConsume("WRITE")
+	next, ok := p.peek()
+	if !ok {
+		return Operation{}, errors.Wrapf(ErrParse, "ALTER TABLE … WRITE: unexpected end: %s", p.stmt)
+	}
+	switch strings.ToUpper(next) {
+	case "UNORDERED":
+		p.consume()
+		return Operation{Kind: SetSortOrder, Table: id, Sort: &SortSpec{Unordered: true}}, nil
+	case "ORDERED":
+		p.consume()
+		if err := p.expectConsume("BY"); err != nil {
+			return Operation{}, err
+		}
+		fields, err := p.parseSortFieldList()
+		if err != nil {
+			return Operation{}, err
+		}
+		return Operation{Kind: SetSortOrder, Table: id, Sort: &SortSpec{Fields: fields}}, nil
+	default:
+		return Operation{}, errors.Wrapf(ErrUnsupportedDDL, "ALTER TABLE … WRITE %s is not supported: %s", next, p.stmt)
+	}
+}
+
+// parseSortFieldList parses a comma-separated list of sort columns following WRITE ORDERED BY.
+// Spark writes the list without surrounding parentheses (WRITE ORDERED BY a, b DESC), but an
+// optional wrapping "(...)" is also accepted for forgiveness.
+func (p *parser) parseSortFieldList() ([]SortField, error) {
+	wrapped := false
+	if p.peekIs("(") {
+		p.consume()
+		wrapped = true
+	}
+
+	fields := make([]SortField, 0, 1)
+	for {
+		sf, err := p.parseSortField()
+		if err != nil {
+			return nil, err
+		}
+		fields = append(fields, sf)
+		if p.peekIs(",") {
+			p.consume()
+			continue
+		}
+		break
+	}
+
+	if wrapped {
+		if err := p.expectConsume(")"); err != nil {
+			return nil, err
+		}
+	}
+	if len(fields) == 0 {
+		return nil, errors.Wrapf(ErrParse, "WRITE ORDERED BY: expected at least one sort column: %s", p.stmt)
+	}
+	return fields, nil
+}
+
+// parseSortField parses a single sort column: "<col-or-transform> [ASC|DESC] [NULLS FIRST|LAST]".
+// A bare identifier maps to an Identity transform; "func(args)" reuses the partition transform parser.
+// Defaults follow Iceberg: direction ASC, and null ordering NULLS FIRST for ASC / NULLS LAST for DESC.
+func (p *parser) parseSortField() (SortField, error) {
+	first, ok := p.peek()
+	if !ok {
+		return SortField{}, errors.Wrapf(ErrParse, "WRITE ORDERED BY: expected sort column: %s", p.stmt)
+	}
+
+	var pf PartitionField
+	// A transform is "<name>(...)": detect it by a '(' immediately following the first token.
+	if p.pos+1 < len(p.tokens) && p.tokens[p.pos+1] == "(" {
+		expr, err := p.collectTransformExprFull()
+		if err != nil {
+			return SortField{}, err
+		}
+		pf, err = parseTransform(expr)
+		if err != nil {
+			return SortField{}, err
+		}
+	} else {
+		p.consume() // plain column
+		pf = PartitionField{Transform: Identity, SourceCol: first}
+	}
+
+	direction := SortAsc
+	switch {
+	case p.peekUpperIs("ASC"):
+		p.consume()
+	case p.peekUpperIs("DESC"):
+		p.consume()
+		direction = SortDesc
+	}
+
+	// Iceberg default null ordering depends on the direction.
+	nullOrder := NullsFirst
+	if direction == SortDesc {
+		nullOrder = NullsLast
+	}
+	if p.peekUpperIs("NULLS") {
+		p.consume()
+		switch {
+		case p.peekUpperIs("FIRST"):
+			p.consume()
+			nullOrder = NullsFirst
+		case p.peekUpperIs("LAST"):
+			p.consume()
+			nullOrder = NullsLast
+		default:
+			return SortField{}, errors.Wrapf(ErrParse, "WRITE ORDERED BY: expected FIRST or LAST after NULLS: %s", p.stmt)
+		}
+	}
+
+	return SortField{
+		Transform: pf.Transform,
+		Param:     pf.Param,
+		SourceCol: pf.SourceCol,
+		Direction: direction,
+		NullOrder: nullOrder,
+	}, nil
 }
 
 // parseAlterAdd handles ADD COLUMN … and ADD PARTITION FIELD …

--- a/internal/infrastructure/iceberg/ddl/parse_test.go
+++ b/internal/infrastructure/iceberg/ddl/parse_test.go
@@ -578,6 +578,165 @@ func TestParse_CreateNamespace_IfNotExists(t *testing.T) {
 	})
 }
 
+// TestParse_CreateTable_IfNotExists verifies that the optional IF NOT EXISTS clause is parsed and
+// recorded in the IR, enabling idempotent table creation (regression: the clause was previously
+// consumed but discarded, so CREATE TABLE IF NOT EXISTS still failed with AlreadyExistsException).
+func TestParse_CreateTable_IfNotExists(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with IF NOT EXISTS", func(t *testing.T) {
+		t.Parallel()
+		op, err := Parse("iceberg", "CREATE TABLE IF NOT EXISTS iceberg.analytics.events (id long)")
+		require.NoError(t, err)
+		assert.Equal(t, CreateTable, op.Kind)
+		assert.Equal(t, []string{"analytics"}, op.Table.Namespace)
+		assert.Equal(t, "events", op.Table.Table)
+		assert.True(t, op.IfNotExists)
+	})
+
+	t.Run("without IF NOT EXISTS", func(t *testing.T) {
+		t.Parallel()
+		op, err := Parse("iceberg", "CREATE TABLE iceberg.analytics.events (id long)")
+		require.NoError(t, err)
+		assert.Equal(t, CreateTable, op.Kind)
+		assert.False(t, op.IfNotExists)
+	})
+}
+
+// TestParse_DropTable_IfExists verifies that the optional IF EXISTS clause is parsed and recorded
+// in the IR, enabling idempotent DROP TABLE (regression: the clause was previously consumed but
+// discarded).
+func TestParse_DropTable_IfExists(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with IF EXISTS", func(t *testing.T) {
+		t.Parallel()
+		op, err := Parse("iceberg", "DROP TABLE IF EXISTS iceberg.analytics.events")
+		require.NoError(t, err)
+		assert.Equal(t, DropTable, op.Kind)
+		assert.Equal(t, []string{"analytics"}, op.Table.Namespace)
+		assert.Equal(t, "events", op.Table.Table)
+		assert.True(t, op.IfExists)
+	})
+
+	t.Run("without IF EXISTS", func(t *testing.T) {
+		t.Parallel()
+		op, err := Parse("iceberg", "DROP TABLE iceberg.analytics.events")
+		require.NoError(t, err)
+		assert.Equal(t, DropTable, op.Kind)
+		assert.False(t, op.IfExists)
+	})
+}
+
+// TestParse_DropNamespace_IfExists verifies that the optional IF EXISTS clause is parsed and
+// recorded in the IR, enabling idempotent DROP NAMESPACE (regression: the parser did not understand
+// IF EXISTS for namespaces at all).
+func TestParse_DropNamespace_IfExists(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with IF EXISTS", func(t *testing.T) {
+		t.Parallel()
+		op, err := Parse("iceberg", "DROP NAMESPACE IF EXISTS iceberg.raw")
+		require.NoError(t, err)
+		assert.Equal(t, DropNamespace, op.Kind)
+		assert.Equal(t, []string{"raw"}, op.Table.Namespace)
+		assert.True(t, op.IfExists)
+	})
+
+	t.Run("without IF EXISTS", func(t *testing.T) {
+		t.Parallel()
+		op, err := Parse("", "DROP NAMESPACE analytics")
+		require.NoError(t, err)
+		assert.Equal(t, DropNamespace, op.Kind)
+		assert.Equal(t, []string{"analytics"}, op.Table.Namespace)
+		assert.False(t, op.IfExists)
+	})
+}
+
+// TestParse_WriteOrderedBy verifies parsing of ALTER TABLE … WRITE ORDERED BY, including
+// direction, null ordering, transforms, defaults, and the WRITE UNORDERED reset form.
+func TestParse_WriteOrderedBy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plain columns with direction and defaults", func(t *testing.T) {
+		t.Parallel()
+		op, err := Parse("iceberg", "ALTER TABLE iceberg.analytics.events WRITE ORDERED BY event_time DESC, user_id")
+		require.NoError(t, err)
+		assert.Equal(t, SetSortOrder, op.Kind)
+		assert.Equal(t, "events", op.Table.Table)
+		require.NotNil(t, op.Sort)
+		assert.False(t, op.Sort.Unordered)
+		require.Len(t, op.Sort.Fields, 2)
+
+		// event_time DESC → direction DESC, default null order NULLS LAST.
+		assert.Equal(t, Identity, op.Sort.Fields[0].Transform)
+		assert.Equal(t, "event_time", op.Sort.Fields[0].SourceCol)
+		assert.Equal(t, SortDesc, op.Sort.Fields[0].Direction)
+		assert.Equal(t, NullsLast, op.Sort.Fields[0].NullOrder)
+
+		// user_id (no direction) → default ASC, default null order NULLS FIRST.
+		assert.Equal(t, "user_id", op.Sort.Fields[1].SourceCol)
+		assert.Equal(t, SortAsc, op.Sort.Fields[1].Direction)
+		assert.Equal(t, NullsFirst, op.Sort.Fields[1].NullOrder)
+	})
+
+	t.Run("explicit NULLS FIRST/LAST overrides default", func(t *testing.T) {
+		t.Parallel()
+		op, err := Parse("", "ALTER TABLE analytics.events WRITE ORDERED BY a ASC NULLS LAST, b DESC NULLS FIRST")
+		require.NoError(t, err)
+		require.NotNil(t, op.Sort)
+		require.Len(t, op.Sort.Fields, 2)
+		assert.Equal(t, SortAsc, op.Sort.Fields[0].Direction)
+		assert.Equal(t, NullsLast, op.Sort.Fields[0].NullOrder)
+		assert.Equal(t, SortDesc, op.Sort.Fields[1].Direction)
+		assert.Equal(t, NullsFirst, op.Sort.Fields[1].NullOrder)
+	})
+
+	t.Run("transform sort column", func(t *testing.T) {
+		t.Parallel()
+		op, err := Parse("", "ALTER TABLE analytics.events WRITE ORDERED BY bucket(16, user_id) DESC, days(event_time)")
+		require.NoError(t, err)
+		require.NotNil(t, op.Sort)
+		require.Len(t, op.Sort.Fields, 2)
+		assert.Equal(t, Bucket, op.Sort.Fields[0].Transform)
+		assert.Equal(t, 16, op.Sort.Fields[0].Param)
+		assert.Equal(t, "user_id", op.Sort.Fields[0].SourceCol)
+		assert.Equal(t, SortDesc, op.Sort.Fields[0].Direction)
+		assert.Equal(t, Days, op.Sort.Fields[1].Transform)
+		assert.Equal(t, "event_time", op.Sort.Fields[1].SourceCol)
+	})
+
+	t.Run("optional surrounding parentheses accepted", func(t *testing.T) {
+		t.Parallel()
+		op, err := Parse("", "ALTER TABLE analytics.events WRITE ORDERED BY (a, b DESC)")
+		require.NoError(t, err)
+		require.NotNil(t, op.Sort)
+		require.Len(t, op.Sort.Fields, 2)
+	})
+
+	t.Run("WRITE UNORDERED clears sort order", func(t *testing.T) {
+		t.Parallel()
+		op, err := Parse("", "ALTER TABLE analytics.events WRITE UNORDERED")
+		require.NoError(t, err)
+		assert.Equal(t, SetSortOrder, op.Kind)
+		require.NotNil(t, op.Sort)
+		assert.True(t, op.Sort.Unordered)
+		assert.Empty(t, op.Sort.Fields)
+	})
+
+	t.Run("unsupported WRITE variant returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := Parse("", "ALTER TABLE analytics.events WRITE DISTRIBUTED BY PARTITION")
+		require.Error(t, err)
+	})
+
+	t.Run("NULLS without FIRST/LAST is a parse error", func(t *testing.T) {
+		t.Parallel()
+		_, err := Parse("", "ALTER TABLE analytics.events WRITE ORDERED BY a NULLS")
+		require.Error(t, err)
+	})
+}
+
 // TestParse_NotNull_OutsideSubset verifies that NOT NULL (outside subset v1) returns ErrParse
 // and does not panic. Field.Required is not supported in subset v1.
 func TestParse_NotNull_OutsideSubset(t *testing.T) {


### PR DESCRIPTION
## Summary

Two Iceberg-driver changes in one commit:

### 1. `IF [NOT] EXISTS` idempotency (fix)
Previously the parser **captured but discarded** the clause for `CREATE TABLE` / `DROP TABLE`, and did not understand it at all for `DROP NAMESPACE`. Re-running `release` / `rollback` therefore failed with `AlreadyExistsException` / `NoSuchTable`.

- Parser now records `IfNotExists` **and** `IfExists`; `ExecQuery` probes existence before create/drop.
- New `catalog.Client.TableExists`: **HEAD-first** (`CheckTableExists`) with a **GET-based `ListTables` fallback** (`SetPageSize(0)`) for older REST catalogs that reject HEAD (same class as the earlier namespace GET-over-HEAD fix). The `headUnsupported` capability is cached so a failed HEAD happens at most once per run.

### 2. `WRITE ORDERED BY` sort order (feature)
Closes the gap where `ALTER TABLE` only supported ADD/DROP/RENAME/ALTER COLUMN and partition fields — sort order could not be expressed.

- `ALTER TABLE <id> WRITE ORDERED BY <col> [ASC|DESC] [NULLS FIRST|LAST], …` and `WRITE UNORDERED`.
- Applied via catalog `CommitTable` (`AddSortOrder` + `SetDefaultSortOrder`, guarded by `AssertTableUUID`) — iceberg-go v0.6.0 has no sort-order transaction builder.
- Sort columns reuse the partition transform vocabulary (`bucket`/`truncate`/`days`/…). Direction defaults to `ASC`; null ordering to Iceberg defaults (`ASC`→`NULLS FIRST`, `DESC`→`NULLS LAST`).
- Setting a sort order is not auto-reversible — `.down.sql` should restore the prior order or use `WRITE UNORDERED`.

## Testing
- `make lint` → 0 issues
- `make test-unit` → pass (new parser + repository unit tests)
- Integration tests against the `iceberg-rest` + MinIO stack:
  - `TestIntegration_Iceberg_IfNotExistsIdempotent` — `release` with a duplicate `CREATE TABLE IF NOT EXISTS`, plus idempotent `DROP TABLE IF EXISTS` / `DROP NAMESPACE IF EXISTS` on down.
  - `TestIntegration_Iceberg_WriteOrderedBy` — sort order over a plain column + `bucket(8, id)` transform, reset via `WRITE UNORDERED`.
  - Full `TestIntegration_Iceberg` suite green (no regressions).
- README DDL subset table updated.